### PR TITLE
replace X#N identifiers with subscripted digits

### DIFF
--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -128,7 +128,7 @@ langProlog = P.LanguageDef
   , P.commentLine = "%"
   , P.nestedComments = True
   , P.identStart = letter <|> char '_'
-  , P.identLetter = alphaNum <|> char '_'
+  , P.identLetter = letter <|> digit <|> char '_'
   , P.opStart = oneOf (map head operatorNames)
   , P.opLetter = oneOf "#$&@*+/<=>\\^~"--sodiv"
   , P.reservedNames = []

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -13,7 +13,7 @@ where
 
 import Data.Generics (Data(..), Typeable(..))
 import Data.List (intercalate)
-import Data.Char (isLetter)
+import Data.Char (digitToInt, isLetter)
 
 
 data Term = Struct Atom [Term]
@@ -120,7 +120,7 @@ operatorTable = concat $ zipWith (map . g) [1..] $ hierarchy False
 
 instance Show VariableName where
    show (VariableName 0 v) = v
-   show (VariableName i v) = v ++ "#" ++  show i
+   show (VariableName i v) = v ++ subscriptDigits i
    show (Wildcard (Just i)) = "_" ++  show i
    show (Wildcard Nothing) = "_"
 
@@ -176,3 +176,19 @@ hierarchy ignoreConjunction =
 
 arguments ts xs ds = ts ++ [ xs, ds ]
 -- arguments ts xs ds = [ xs \\ ds ] ++ ts
+
+
+subscriptDigits :: Int -> String
+subscriptDigits 0 = "₀"
+subscriptDigits 1 = "₁"
+subscriptDigits 2 = "₂"
+subscriptDigits 3 = "₃"
+subscriptDigits 4 = "₄"
+subscriptDigits 5 = "₅"
+subscriptDigits 6 = "₆"
+subscriptDigits 7 = "₇"
+subscriptDigits 8 = "₈"
+subscriptDigits 9 = "₉"
+subscriptDigits i
+  | i < 0     = error "negative number in identifier subscript"
+  | otherwise = concatMap (subscriptDigits . digitToInt) $ show i


### PR DESCRIPTION
doing this here since `prolog-graph-lib` just uses the `Show` instance of `VariableName` from here to render the labels.

I tried building HTML labels through the Graphviz library first, but the result required a lot of changes to `prolog-graph-lib` and also didn't look great. (Replacement only in the unifiers here)


<img width="404" height="289" alt="bad" src="https://github.com/user-attachments/assets/f0a1bc85-a8dd-4066-9592-f71e093c5efd" />

You can see that the subscript numbers leave quite a large gap to the variable name. The library does not allow for any fine tuning of that, so we would be stuck with that look.

I decided to use Unicode subscript digits instead, which look a lot better:

<img width="377" height="289" alt="graph" src="https://github.com/user-attachments/assets/51b60f2e-05cc-4c91-bbfd-2596a70e28bd" />


I've also adjusted the user facing parser to not accept non ASCII number anymore. Previously you could use subscript, as well as other unusual digits like ٤ in variable names, which I think is not intended (and this would lead to bad formatting of these new identifiers if the user input already contained subscript). Please let me know if you want this re-enabled.